### PR TITLE
Lint runner for newly modified files

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+/**
+ * @fileoverview This CLI helps to run lint rules as errors in files
+ *   which has new changes that are yet to be pushed to remote branch
+ * @author Kiddom Inc.
+ */
+
+const { CLIEngine, linter } = require("eslint");
+const { execFile, execFileSync } = require('child_process');
+const { existsSync } = require('fs');
+const path = require('path');
+
+const { argv } = require('yargs')
+  .usage('Usage: $0 [options]')
+  .alias('r', 'remote')
+  .nargs('r', 1)
+  .example('$0 -r upstream/master', 'Set remote branch as upstream/master')
+  .describe('r', 'remote branch defaults to origin/master')
+  .alias('f', 'format')
+  .nargs('f', 1)
+  .example('$0 -f compact', 'Set report formatter as compact')
+  .describe('f', 'formatter for lint report. Default to eslint default. If there is no matching formatter, fallback to default')
+  .help('h')
+  .alias('h', 'help')
+  .epilog(`Made with ♥︎ by Kiddom Inc
+copyright 2016-2017`);
+
+// git base path
+let basePath;
+try {
+  basePath = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    encoding: 'utf8'
+  }).trim();
+} catch (e) {
+  console.error(e.message);
+  console.error('Failed to detect git root path');
+  process.exit(-1);
+}
+
+const r = argv.r || 'origin/master';
+const ruleCLI = new CLIEngine({
+  // default is true, still for readability
+  useEslintrc: true,
+  extensions: ['js', 'jsx']
+});
+
+const filterFile = f =>
+  f &&
+  f.length > 0 &&
+  ruleCLI.options.extensions.indexOf(path.extname(f).substr(1)) !== -1;
+
+const fixReport = report => {
+  report.errorCount += report.warningCount;
+  report.warningCount = 0;
+  const { results } = report;
+  results.forEach(r => {
+    r.errorCount += r.warningCount;
+    r.warningCount = 0;
+    r.messages.forEach(m => m.severity = 2);
+  });
+  return report;
+};
+
+execFile('git', ['diff', '--name-only', r], (error, out, err) => {
+  if (error || err) {
+    console.error(error || err);
+    process.exit(-1);
+  }
+
+  // list of files to be processed
+  const files = out
+    .split('\n')
+    .filter(filterFile)
+    .map(n => path.join(basePath, n))
+    .filter(existsSync);
+
+  if (!files.length) {
+  	process.exit(0);
+  }
+
+  const report = fixReport(ruleCLI.executeOnFiles(files));
+  if (report.errorCount) {
+    const formatter = ruleCLI.getFormatter(argv.f) || ruleCLI.getFormatter();
+    console.log(formatter(report.results));
+    process.exit(-1);
+  }
+
+  process.exit(0);
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "test": "mocha tests --recursive"
   },
   "dependencies": {
-    "requireindex": "~1.1.0"
+    "babel-eslint": "^7.1.1",
+    "eslint": "^2.6.0",
+    "requireindex": "~1.1.0",
+    "yargs": "^6.5.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.0.0",


### PR DESCRIPTION
CLI helps to run lint rules as errors in files which has new changes that are yet to be pushed to remote branch

Usage:
```js

eslint-plugin-kiddomstyle 🙈 ₹ git:(upstream ⚡ lint-runner) 1A 1A ./lib/runner.js  -h
Usage: lib/runner.js [options]

Options:
  -r, --remote  remote branch defaults to origin/master
  -f, --format  formatter for lint report. Default to eslint default. If there
                is no matching formatter, fallback to default
  -h, --help    Show help                                              [boolean]

Examples:
  lib/runner.js -r upstream/master  Set remote branch as upstream/master
  lib/runner.js -f compact          Set report formatter as compact

Made with ♥︎ by Kiddom Inc
copyright 2016-2017

eslint-plugin-kiddomstyle 🙈 ₹ git:(upstream ⚡ lint-runner) 1A 1A

```
Add this runner script to git pre-commit, push hooks for auto checking without explicit run!